### PR TITLE
instructions for tests and azure readiness

### DIFF
--- a/common/template/.kilocode/rules/azure_ready_fastapi.md
+++ b/common/template/.kilocode/rules/azure_ready_fastapi.md
@@ -1,0 +1,235 @@
+
+# LLM Credentials: Client-Supplied Only (Azuring / OpenAI-compatible endpoints)
+
+This document is a precise, prescriptive reference for implementers and test-writers. It clarifies the new, strict policy: clients must supply LLM credentials on every request. There is no fallback to configuration, environment variables, Docker secrets, or any global/static object — with one narrow exception for non-LLM sensitive values managed via aiweb_common helpers (see "Non-LLM sensitive values" below).
+
+Use this document as: Requirements → Rationale → Examples → Testing / Mocks → Notes.
+
+---
+
+## Requirements (must-read, top of file)
+
+- Every request that may trigger an LLM call MUST include these JSON fields in the request body:
+  - `openai_compatible_endpoint` — the full URL (string) of the OpenAI-compatible endpoint to call.
+  - `openai_compatible_model` — the model name (string) to use at that endpoint.
+
+- Every request MUST include the API key in the HTTP `Authorization` header using the Bearer scheme:
+  - Example header:
+    ```
+    Authorization: Bearer <api_key>
+    ```
+
+- There is absolutely NO fallback for LLM credentials. Under no circumstances will the server:
+  - Read an LLM API key from configuration files, environment variables, Docker secrets, or any global/static object.
+  - Use any server-side default model or endpoint when client-provided values are missing.
+  - Accept a missing header or missing JSON endpoint/model and substitute values from the application config.
+
+- Endpoints that perform LLM calls MUST validate for these credentials and return a client error (422) when the required fields are missing, and return 500 for LLM-client-side failures (e.g., unauthorized from LLM provider) as appropriate.
+
+---
+
+## Rationale
+
+- Multi-tenant and custom-hosting scenarios require the client to control which LLM endpoint and model are used per request.
+- Explicit credentials per-request avoid accidental credential leakage across tenants and remove ambiguity from tests and deploys.
+- Tests and implementers must be explicit: provide endpoint + model in JSON, and API key in Authorization header.
+
+---
+
+## Where this applies
+
+- Any API route that triggers a workflow which makes an LLM call must follow this policy. For example, the workflow code referenced in [`meeting_notes/workflows.py`](meeting_notes/workflows.py:1) and the request models defined under [`app/v01/schemas.py`](app/v01/schemas.py:1) should reflect and validate these fields.
+- Update request schemas and endpoint handlers so that the JSON body contains `openai_compatible_endpoint` and `openai_compatible_model`, and so the code reads the API key from `Authorization` header for each request.
+
+---
+
+## Example: Required request shape (JSON body)
+
+Example JSON body that MUST be included with the POST:
+
+```json
+{
+  "query": "How many patients match X?",
+  "source": "mpog",
+  "openai_compatible_endpoint": "https://example-openai-compatible-host/",
+  "openai_compatible_model": "gpt-4-azure"
+}
+```
+
+Required header example (exact form):
+
+```
+Authorization: Bearer test-api-key-123
+```
+
+Put another way: JSON includes endpoint+model; header includes the API key.
+
+---
+
+## Non-LLM sensitive values
+
+- The above strict "no fallback" rule applies only to LLM credentials (endpoint, model, API key). It does NOT prevent using configured secrets for non-LLM integrations (for example, external APIs, databases, or other service keys).
+- For non-LLM sensitive values you may continue to use the repository's secret management helpers. Example pattern used elsewhere:
+
+```python
+from aiweb_common.WorkflowHandler import manage_sensitive
+
+NAME = "lit"
+
+# Non-LLM sensitive secrets (managed via aiweb_common helpers)
+LIBKEY_API_KEY = manage_sensitive("libkey_api_key")
+NCBI_API_KEY = manage_sensitive("ncbi_api_key")
+```
+
+- Do NOT use manage_sensitive (or any config-secret helper) to supply LLM API keys or default LLM endpoints/models. LLM credentials must always come from the client per-request.
+
+---
+
+## Implementation guidance (for implementers)
+
+1. Request validation
+   - Ensure your request model (e.g., pydantic model in [`app/v01/schemas.py`](app/v01/schemas.py:1)) lists `openai_compatible_endpoint` and `openai_compatible_model` as required fields.
+   - Ensure you check/parse the `Authorization` header and reject requests without a Bearer token.
+
+2. Avoid global/static Chat objects
+   - Do not instantiate `ChatOpenAI` or equivalent LLM client as a global singleton with credentials from config. Instead, instantiate per-request using the provided endpoint, model, and API key.
+   - If code currently reads credentials from `meeting_notes_config/config.py` or similar, change it to accept per-request parameters at the call site. (If you see code inconsistencies, see the "Notes" section at the end.)
+   - Rather, use the method aiweb_common.WorkflowHandler provides to anything that superclasses it:
+   ```python
+   class WorkflowHandler(ABC):
+    def __init__(self):
+        self.total_cost = 0.0
+
+    def _init_openai(self, *, openai_compatible_endpoint, openai_compatible_key, openai_compatible_model, name):
+        self.llm_interface = ChatOpenAI(
+            base_url=openai_compatible_endpoint,
+            api_key=openai_compatible_key,
+            model=openai_compatible_model,
+            user=name
+        )
+    ```
+    
+    As an example from another project:
+
+    ```python
+    class TranscriptWorkflow(WorkflowHandler):
+    def __init__(self, txt_content, openai_compatible_endpoint, openai_compatible_key, openai_compatible_model):
+        super().__init__()
+        self.txt_content = txt_content
+        # Initialize a per-instance LLM interface using WorkflowHandler helper.
+        self._init_openai(
+            openai_compatible_endpoint=openai_compatible_endpoint,
+            openai_compatible_key=openai_compatible_key,
+            openai_compatible_model=openai_compatible_model,
+            name=config.APP_NAME if hasattr(config, "APP_NAME") else "TranscriptWorkflow"
+        )
+
+    def process(self):
+        """
+        The function processes a transcript document by extracting relevant text, assembling a prompt, generating a
+        response using a search response handler, and updating the total cost.
+
+        Returns:
+          The `process` method returns the `generated_response` after processing the search response,
+        extracting relevant text from the transcript document, assembling a prompt, and generating a response based
+        on the assembled prompt.
+        """
+        print("initiating single response handler")
+        # Use the per-instance LLM interface initialized via self._init_openai instead of the global config
+        single_response = SingleResponseHandler(self.llm_interface)
+
+        assembled_prompt = self._assemble_prompt(single_response)
+
+        generated_response, response_meta = single_response.generate_response(assembled_prompt)
+        self._update_total_cost(response_meta)
+
+        final_text = generated_response.content
+        print("output text - ", final_text)
+        return final_text
+    ```
+    
+3. Logging and error handling
+   - Log only metadata (e.g., endpoint hostname, model) — do not log API keys.
+   - For downstream LLM errors (e.g., unauthorized), propagate as  500 so tests can assert behavior.
+
+4. Examples of where to read values in code
+   - Read `request.json()["openai_compatible_endpoint"]` and `request.json()["openai_compatible_model"]`.
+   - Read API key from FastAPI `Authorization` header (e.g., `Authorization: Bearer <api_key>`).
+
+---
+
+## Testing
+
+Testing guidance is centralized in `common/template/.kilocode/rules/test_style_guide.md`.
+Follow that guide for required credentials, mocks, patch locations, and FastAPI
+client setup to avoid duplicating instructions here.
+- Patch symbols as they are imported by the module under test (not necessarily where they are defined).
+  - If `meeting_notes.workflows` does `from aiweb_common.generate.PromptyHandler import PromptyHandler`, patch:
+    - `"meeting_notes.workflows.PromptyHandler.generate_response"` or `"meeting_notes.workflows.PromptyHandler"`.
+  - If a per-request Chat/LLM object is constructed via a config import in the workflow file, patch:
+    - `"meeting_notes.workflows.config.ChatOpenAI"` (or whichever symbol name is actually used in that module).
+  - For the RAG handler used by the workflow, patch:
+    - `"meeting_notes.workflows.RAGResponseHandler"`.
+
+Common gotchas
+- Patching the wrong import path (patch has no effect). If your patch doesn't change behavior, check the import locations in the module under test (e.g., [`meeting_notes/workflows.py`](meeting_notes/workflows.py:1)).
+- Mock return shapes must match what the code consumes (tuple shape, attributes like `.content`).
+- Do not assert API keys or include actual API keys in logs.
+
+---
+
+## Simulating error cases (examples)
+
+Missing fields → expect 422:
+```python
+def test_missing_fields_returns_422():
+    payload = {"query": "a", "source": "mpog"}  # missing endpoint/model
+    headers = {"Authorization": "Bearer test-api-key-123"}
+    resp = client.post("/idea/v01/", json=payload, headers=headers)
+    assert resp.status_code == 422
+```
+
+Invalid/unauthorized API key → simulate by making the mocked Chat class raise an exception:
+```python
+from unittest.mock import patch
+
+def test_invalid_api_key_results_in_500():
+    payload = {
+        "query": "q",
+        "source": "mpog",
+        "openai_compatible_endpoint": "https://example/",
+        "openai_compatible_model": "gpt-4-azure"
+    }
+    headers = {"Authorization": "Bearer bad-key"}
+    # Patch the Chat constructor or call site used by the workflow to raise
+    with patch("meeting_notes.workflows.config.ChatOpenAI") as mock_chat:
+        mock_chat.side_effect = Exception("unauthorized")
+        resp = client.post("/idea/v01/", json=payload, headers=headers)
+        assert resp.status_code == 500
+```
+
+---
+
+## Checklist: converting an existing test (short)
+
+- [ ] Add `openai_compatible_endpoint` and `openai_compatible_model` to the JSON request body.
+- [ ] Add `Authorization: Bearer <api_key>` header to the request.
+- [ ] Patch:
+  - [ ] The Chat/LLM class used by the workflow (patch the name as imported in [`meeting_notes/workflows.py`](meeting_notes/workflows.py:1)).
+  - [ ] `PromptyHandler.generate_response` where it is imported by the code under test.
+  - [ ] `RAGResponseHandler` or its `aug_service.retrieve_data`.
+  - [ ] `tiktoken.encoding_for_model` if referenced.
+- [ ] Assert status codes: 200 (success), 422 (missing client credentials), 500 (LLM-side errors).
+
+---
+
+## Notes (observations about this repository — do not change code here)
+
+- The original `azurify.md` referenced `DataFeasibility/*` modules (e.g., [`DataFeasibility/workflows.py`](DataFeasibility/workflows.py:1)). In this repository the main workflow code is located at [`meeting_notes/workflows.py`](meeting_notes/workflows.py:1). Update references in developer knowledge or tests to point at `meeting_notes.*` import paths when patching.
+- Some examples in the original document referenced `app/v01/idea.py` and `app/v01/schemas.py` but included parameter names like `llm_api_key` and `llm_model_name` that differ from the canonical names required here (`openai_compatible_endpoint`, `openai_compatible_model`, and API key in the `Authorization` header). Ensure any code or tests you update use the JSON fields (`openai_compatible_*`) and the Authorization header, not additional body fields for keys.
+- A few earlier examples suggested patch targets under `DataFeasibility.workflows` (e.g., `DataFeasibility.workflows.config.ChatOpenAI`). In this repo, similar patch targets are likely under `meeting_notes.workflows` (e.g., `meeting_notes.workflows.config.ChatOpenAI`) — verify actual import lines in the module before patching.
+- Tests in `tests/fastapi_tests/v01/` already exercise the upload/evaluation routes; ensure any converted tests in this repo follow the header+body requirement described above.
+
+---
+
+This file updates and centralizes the policy: clients must always supply `openai_compatible_endpoint`, `openai_compatible_model` in the request body and an API key in `Authorization: Bearer <api_key>`. No fallbacks are allowed.

--- a/common/template/.kilocode/rules/azure_ready_gradio.md
+++ b/common/template/.kilocode/rules/azure_ready_gradio.md
@@ -1,0 +1,178 @@
+
+# LLM Credentials: Client-Supplied Only (Gradio / OpenAI-compatible endpoints)
+
+This document is a precise, prescriptive reference for implementers and test-writers. It clarifies the new, strict policy: clients must supply LLM credentials on every request. There is no fallback to configuration, environment variables, Docker secrets, or any global/static object — with one narrow exception for non-LLM sensitive values managed via aiweb_common helpers (see "Non-LLM sensitive values" below).
+
+Use this document as: Requirements → Rationale → Examples → Testing / Mocks → Notes.
+
+---
+
+## Requirements (must-read, top of file)
+
+- Every request that may trigger an LLM call MUST include these JSON fields in the request body:
+  - `openai_compatible_endpoint` — the full URL (string) of the OpenAI-compatible endpoint to call.
+  - `openai_compatible_model` — the model name (string) to use at that endpoint.
+
+- Every request MUST include the API key in the HTTP `Authorization` header using the Bearer scheme:
+  - Example header:
+    ```
+    Authorization: Bearer <api_key>
+    ```
+
+- There is absolutely NO fallback for LLM credentials. Under no circumstances will the server:
+  - Read an LLM API key from configuration files, environment variables, Docker secrets, or any global/static object.
+  - Use any server-side default model or endpoint when client-provided values are missing.
+  - Accept a missing header or missing JSON endpoint/model and substitute values from the application config.
+
+- Endpoints that perform LLM calls MUST validate for these credentials and return a client error when the required fields are missing. For Gradio handlers, raise `gr.Error` and let the API layer translate to a 4xx response.
+
+---
+
+## Rationale
+
+- Multi-tenant and custom-hosting scenarios require the client to control which LLM endpoint and model are used per request.
+- Explicit credentials per-request avoid accidental credential leakage across tenants and remove ambiguity from tests and deploys.
+- Tests and implementers must be explicit: provide endpoint + model in JSON, and API key in Authorization header.
+
+---
+
+## Where this applies
+
+- Any Gradio endpoint (`api_name`) that triggers an LLM call must follow this policy. For example, the workflow code referenced in [`meeting_notes/workflows.py`](meeting_notes/workflows.py:1) and the request models defined under [`app/v01/schemas.py`](app/v01/schemas.py:1) should reflect and validate these fields.
+- Update request schemas and Gradio handlers so that the JSON body contains `openai_compatible_endpoint` and `openai_compatible_model`, and so the code reads the API key from `Authorization` header for each request.
+
+---
+
+## Example: Required request shape (JSON body)
+
+Example JSON body that MUST be included with the POST:
+
+```json
+{
+  "query": "How many patients match X?",
+  "source": "mpog",
+  "openai_compatible_endpoint": "https://example-openai-compatible-host/",
+  "openai_compatible_model": "gpt-4-azure"
+}
+```
+
+Required header example (exact form):
+
+```
+Authorization: Bearer test-api-key-123
+```
+
+Put another way: JSON includes endpoint+model; header includes the API key.
+
+---
+
+## Non-LLM sensitive values
+
+- The above strict "no fallback" rule applies only to LLM credentials (endpoint, model, API key). It does NOT prevent using configured secrets for non-LLM integrations (for example, external APIs, databases, or other service keys).
+- For non-LLM sensitive values you may continue to use the repository's secret management helpers. Example pattern used elsewhere:
+
+```python
+from aiweb_common.WorkflowHandler import manage_sensitive
+
+NAME = "lit"
+
+# Non-LLM sensitive secrets (managed via aiweb_common helpers)
+LIBKEY_API_KEY = manage_sensitive("libkey_api_key")
+NCBI_API_KEY = manage_sensitive("ncbi_api_key")
+```
+
+- Do NOT use manage_sensitive (or any config-secret helper) to supply LLM API keys or default LLM endpoints/models. LLM credentials must always come from the client per-request.
+
+---
+
+## Implementation guidance (for implementers)
+
+1. Request validation
+   - Ensure your request model (e.g., pydantic model in [`app/v01/schemas.py`](app/v01/schemas.py:1)) lists `openai_compatible_endpoint` and `openai_compatible_model` as required fields.
+   - Ensure you check/parse the `Authorization` header via `gr.Request` and reject requests without a Bearer token.
+
+2. Avoid global/static Chat objects
+   - Do not instantiate `ChatOpenAI` or equivalent LLM client as a global singleton with credentials from config. Instead, instantiate per-request using the provided endpoint, model, and API key.
+   - If code currently reads credentials from `meeting_notes_config/config.py` or similar, change it to accept per-request parameters at the call site. (If you see code inconsistencies, see the "Notes" section at the end.)
+   - Rather, use the method aiweb_common.WorkflowHandler provides to anything that superclasses it:
+   ```python
+   class WorkflowHandler(ABC):
+    def __init__(self):
+        self.total_cost = 0.0
+
+    def _init_openai(self, *, openai_compatible_endpoint, openai_compatible_key, openai_compatible_model, name):
+        self.llm_interface = ChatOpenAI(
+            base_url=openai_compatible_endpoint,
+            api_key=openai_compatible_key,
+            model=openai_compatible_model,
+            user=name
+        )
+    ```
+    
+    As an example from another project:
+
+    ```python
+    class TranscriptWorkflow(WorkflowHandler):
+    def __init__(self, txt_content, openai_compatible_endpoint, openai_compatible_key, openai_compatible_model):
+        super().__init__()
+        self.txt_content = txt_content
+        # Initialize a per-instance LLM interface using WorkflowHandler helper.
+        self._init_openai(
+            openai_compatible_endpoint=openai_compatible_endpoint,
+            openai_compatible_key=openai_compatible_key,
+            openai_compatible_model=openai_compatible_model,
+            name=config.APP_NAME if hasattr(config, "APP_NAME") else "TranscriptWorkflow"
+        )
+
+    def process(self):
+        """
+        The function processes a transcript document by extracting relevant text, assembling a prompt, generating a
+        response using a search response handler, and updating the total cost.
+
+        Returns:
+          The `process` method returns the `generated_response` after processing the search response,
+        extracting relevant text from the transcript document, assembling a prompt, and generating a response based
+        on the assembled prompt.
+        """
+        print("initiating single response handler")
+        # Use the per-instance LLM interface initialized via self._init_openai instead of the global config
+        single_response = SingleResponseHandler(self.llm_interface)
+
+        assembled_prompt = self._assemble_prompt(single_response)
+
+        generated_response, response_meta = single_response.generate_response(assembled_prompt)
+        self._update_total_cost(response_meta)
+
+        final_text = generated_response.content
+        print("output text - ", final_text)
+        return final_text
+    ```
+    
+3. Logging and error handling
+   - Log only metadata (e.g., endpoint hostname, model) — do not log API keys.
+   - For downstream LLM errors (e.g., unauthorized), propagate as 500 so tests can assert behavior.
+
+4. Examples of where to read values in code
+   - Read `openai_compatible_endpoint` and `openai_compatible_model` from the request payload passed to your Gradio handler.
+   - Read API key from `gr.Request.headers["authorization"]` (e.g., `Authorization: Bearer <api_key>`).
+
+---
+
+## Testing
+
+Testing guidance has moved to `docs/test_style_guide.md` to keep it shared
+across Gradio and FastAPI apps. Follow that guide for mocks, patching, and
+client setup.
+
+---
+
+## Notes (observations about this repository — do not change code here)
+
+- The original `azurify.md` referenced `DataFeasibility/*` modules (e.g., [`DataFeasibility/workflows.py`](DataFeasibility/workflows.py:1)). In this repository the main workflow code is located at elsewhere but similarly patterned. Update references in developer knowledge or tests to point at appropriate import paths when patching.
+- Some examples in the original document referenced `app/v01/idea.py` and `app/v01/schemas.py` but included parameter names like `llm_api_key` and `llm_model_name` that differ from the canonical names required here (`openai_compatible_endpoint`, `openai_compatible_model`, and API key in the `Authorization` header). Ensure any code or tests you update use the JSON fields (`openai_compatible_*`) and the Authorization header, not additional body fields for keys.
+- A few earlier examples suggested patch targets under `DataFeasibility.workflows` (e.g., `DataFeasibility.workflows.config.ChatOpenAI`). In this repo, similar patch targets are elsewhere — verify actual import lines in the module before patching.
+- Ensure any converted tests in this repo follow the header+body requirement described above.
+
+---
+
+This file updates and centralizes the policy: clients must always supply `openai_compatible_endpoint`, `openai_compatible_model` in the request body and an API key in `Authorization: Bearer <api_key>`. No fallbacks are allowed.

--- a/common/template/.kilocode/rules/gradio_style_guide.md
+++ b/common/template/.kilocode/rules/gradio_style_guide.md
@@ -1,0 +1,57 @@
+# Gradio App Style Guide
+
+This guide defines how we build Gradio apps in this repo. It reflects our current
+decision to keep base64 file exchange and to prefer reuse of `aiweb_common` helpers,
+even if they are named for FastAPI.
+
+## Goals
+- Keep backends stateless and deterministic.
+- Expose stable APIs via Gradio `api_name` for the TypeScript frontend.
+- Keep UI and business logic modular and testable.
+
+## Project Structure
+Use a split between UI layout and pure handlers:
+- `app/app.py`: Gradio entrypoint, composes UI modules.
+- `app/v01/gradio_ui.py`: UI composition (Blocks/Tabs/Accordions).
+- `app/v01/gradio_handlers.py`: pure functions with minimal side effects.
+- `app/v01/schemas.py`: Pydantic request/response validation.
+- `app/v01/validators.py`: MIME validators via `aiweb_common`.
+- `app/v01/file_processing.py`: shared helpers (e.g., base64 decode/encode).
+
+## Handlers (Business Logic)
+- Keep handlers pure and idempotent when possible.
+- Validate inputs with Pydantic models (`schemas.py`) before processing.
+- Use `aiweb_common` helpers if they exist, even if named for FastAPI:
+  - `FastAPIUploadManager` for base64 decode + file parsing.
+  - `FastAPIDocxCreator` for docx generation.
+  - `aiweb_common.fastapi.schemas` for response shapes (e.g., `MSWordResponse`).
+- Avoid long-lived state; use in-memory variables only within a request.
+- Raise `gr.Error` for user-facing errors.
+
+## UI Composition
+- Keep UI layout in `gradio_ui.py` with minimal logic.
+- Use `api_name` on event bindings for stable API routes.
+- Prefer components with explicit types (e.g., `gr.File(type="filepath")`).
+- Keep the primary app layout in `app/app.py` and import UI modules.
+
+## Base64 File Strategy (Current Standard)
+- Accept base64 inputs for file payloads.
+- Validate MIME types using `aiweb_common.file_operations.file_handling`.
+- Use base64 responses for file downloads unless and until we switch.
+- Document expected file extensions in the Pydantic schema.
+
+## Statelessness Rules
+- Do not rely on server-local persistence between requests.
+- If you write temp files, delete them in the same request.
+- Do not cache user data or store files on disk beyond request scope.
+
+## API Naming
+- Use stable, versioned `api_name` values (e.g., `v01_tab1_process_csv`).
+- Do not change existing names without a deprecation plan.
+
+## When to Propose Changes
+- If a helper is missing and would help multiple apps, propose adding it to
+  `llm_utils` instead of duplicating it locally.
+
+## Cross-Project Rules
+- Follow `.kilocode/rules` for security, formatting, naming, and testing standards.

--- a/common/template/.kilocode/rules/test_style_guide.md
+++ b/common/template/.kilocode/rules/test_style_guide.md
@@ -1,0 +1,102 @@
+# Test Style Guide (FastAPI + Gradio)
+
+This guide covers shared testing rules for endpoints that trigger LLM workflows.
+It applies to both FastAPI and Gradio apps; framework-specific notes are included
+where needed.
+
+## Credential Requirements (Mandatory)
+Every test that touches LLM workflows must:
+- Include `openai_compatible_endpoint` in the JSON payload.
+- Include `openai_compatible_model` in the JSON payload.
+- Include `Authorization: Bearer <api_key>` in the request headers.
+
+If any of these are missing, tests must assert a client error response.
+
+## What to Mock (and Why)
+- The object that performs LLM calls (e.g., Chat/LLM class) to avoid network calls.
+- The prompt handling helper (e.g., `PromptyHandler.generate_response`) for deterministic output.
+- The RAG handler or retrieval layer (`RAGResponseHandler` or `aug_service.retrieve_data`).
+- `tiktoken.encoding_for_model` if referenced.
+
+## Mock Shapes
+- `PromptyHandler.generate_response` returns `(result_object, result_meta)`.
+  - `result_object.content` is a string.
+  - `result_meta` includes any fields your code reads (e.g., `.total_cost`).
+
+## Patch Locations
+Patch symbols where they are imported by the module under test.
+Example: if `meeting_notes.workflows` imports `PromptyHandler`, patch
+`meeting_notes.workflows.PromptyHandler.generate_response`.
+
+## Assertions
+- Success path returns 200 and the expected shape (e.g., `{"content": "<string>"}`).
+- Missing endpoint/model or Authorization header returns a 4xx client error.
+- Downstream LLM errors (simulated via mocks) raise a 5xx error.
+
+## Framework-Specific Notes
+
+### Gradio
+- Use `gradio_client.Client` against the running app.
+- Pass headers at client initialization.
+- If your client helper cannot pass headers, use `requests.post` against
+  `/api/<api_name>` and include `Authorization`.
+
+Example:
+```python
+from unittest.mock import Mock, patch
+from gradio_client import Client
+
+def test_idea_endpoint_happy_path():
+    payload = {
+        "query": "test query",
+        "source": "mpog",
+        "openai_compatible_endpoint": "https://example-openai-compatible-host/",
+        "openai_compatible_model": "gpt-4-azure",
+    }
+    headers = {"Authorization": "Bearer test-api-key-123"}
+
+    with patch("meeting_notes.workflows.PromptyHandler.generate_response") as mock_generate:
+        result_object = Mock()
+        result_object.content = "mocked content"
+        result_meta = Mock()
+        result_meta.total_cost = 0.0
+        mock_generate.return_value = (result_object, result_meta)
+
+        client = Client("http://localhost:7860", headers=headers)
+        response = client.predict(payload, api_name="/idea_v01")
+        assert response["content"] == "mocked content"
+```
+
+### FastAPI
+- Use `fastapi.testclient.TestClient` against the app object.
+- Pass headers with each request.
+
+Example:
+```python
+from unittest.mock import Mock, patch
+from fastapi.testclient import TestClient
+from app.server import app
+
+client = TestClient(app)
+
+def test_idea_endpoint_happy_path():
+    payload = {
+        "query": "test query",
+        "source": "mpog",
+        "openai_compatible_endpoint": "https://example-openai-compatible-host/",
+        "openai_compatible_model": "gpt-4-azure",
+    }
+    headers = {"Authorization": "Bearer test-api-key-123"}
+
+    with patch("meeting_notes.workflows.PromptyHandler.generate_response") as mock_generate:
+        result_object = Mock()
+        result_object.content = "mocked content"
+        result_meta = Mock()
+        result_meta.total_cost = 0.0
+        mock_generate.return_value = (result_object, result_meta)
+
+        response = client.post("/idea/v01/", json=payload, headers=headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["content"] == "mocked content"
+```


### PR DESCRIPTION
Instructions for making endpoints azure-read and developing tests that are more realistic to the azure setup.

@rcg-uab the fastapi and gradio rules can be split up if we want to eventually make a third project type "gradio"? I think we went back and forth on that, but maybe it's cleanest.