### PR TITLE
Remove hardcoded service prefix from template routes

### DIFF
--- a/fastapi_app/template/{{project_name}}/app/fastapi_config.py.jinja
+++ b/fastapi_app/template/{{project_name}}/app/fastapi_config.py.jinja
@@ -1,6 +1,13 @@
+import os
+
 CSV_EXPECTED_TYPE = "text/csv"
 
+# ROOT_PATH is set by the Traefik reverse proxy (e.g. /app, /irb).
+# It tells FastAPI the external URL prefix for OpenAPI docs without
+# affecting route matching.  Do NOT hardcode this prefix into route
+# decorators — Traefik StripPrefix removes it before forwarding.
 FORM_API_META = {
+    "root_path": os.environ.get("ROOT_PATH", ""),
     "title": "{{project_name}}",
     "description": "{{description}}",
     "summary": "Brought to you by the Anesthesiology Research, Informatics, and Data Science teams in collaboration with Radiology Imaging Informatics, Clinicians, and Researchers.",

--- a/fastapi_app/template/{{project_name}}/app/server.py
+++ b/fastapi_app/template/{{project_name}}/app/server.py
@@ -9,6 +9,9 @@ from app.v01.tab2 import router as v01_tab2_router
 
 app = FastAPI(**FORM_API_META)
 app.include_router(utils_router)
+# Route paths are clean (/v01/tab1, not /app/v01/tab1).
+# The service prefix is set via ROOT_PATH env var for OpenAPI docs
+# and handled by Traefik StripPrefix for request routing.
 app.include_router(v01_tab1_router)
 app.include_router(v01_tab2_router)
 

--- a/fastapi_app/template/{{project_name}}/app/v01/tab1.py
+++ b/fastapi_app/template/{{project_name}}/app/v01/tab1.py
@@ -40,7 +40,10 @@ def get_task_response(
     return response
 
 
-@router.post("/app/v01/tab1", **TAB1_META)
+# Route paths must NOT include the service prefix (e.g. /app).
+# Traefik StripPrefix handles the prefix — hardcoding it here
+# causes doubled prefixes and 404s behind the reverse proxy.
+@router.post("/v01/tab1", **TAB1_META)
 async def process_file(
     background_tasks: BackgroundTasks, request: FileInRequest
 ) -> DataFrameResponse:

--- a/fastapi_app/template/{{project_name}}/app/v01/tab2.py.jinja
+++ b/fastapi_app/template/{{project_name}}/app/v01/tab2.py.jinja
@@ -24,7 +24,10 @@ def get_task_response(background_tasks: BackgroundTasks) -> MSWordResponse:
 
 
 
-@router.post("/app/v01/tab2", **TAB2_META)
+# Route paths must NOT include the service prefix (e.g. /app).
+# Traefik StripPrefix handles the prefix — hardcoding it here
+# causes doubled prefixes and 404s behind the reverse proxy.
+@router.post("/v01/tab2", **TAB2_META)
 async def process_file(background_tasks: BackgroundTasks) -> MSWordResponse:
     #This example task returns a Docx document.
     response = get_task_response(background_tasks)

--- a/fastapi_app/template/{{project_name}}/tests/fastapi_tests/v01/test_file_upload.py
+++ b/fastapi_app/template/{{project_name}}/tests/fastapi_tests/v01/test_file_upload.py
@@ -7,7 +7,8 @@ def test_file_upload(client, encoded_data):
     Tests the POST method for drafting a introduction to ensure it handles the input correctly and returns the expected response.
     """
     # URL for the POST request
-    url = "/app/v01/tab1"
+    # Paths in tests must match the route decorator — no service prefix.
+    url = "/v01/tab1"
 
     # The payload containing the base64-encoded DOCX file
     # Ensure areas_of_excellence is a list of enum values

--- a/fastapi_app/template/{{project_name}}/tests/fastapi_tests/v01/test_report_download.py
+++ b/fastapi_app/template/{{project_name}}/tests/fastapi_tests/v01/test_report_download.py
@@ -14,7 +14,8 @@ def test_report_download():
     # Create a test client using the FastAPI application
     client = TestClient(app)
     # URL for the POST request
-    url = "/app/v01/tab2"
+    # Paths in tests must match the route decorator — no service prefix.
+    url = "/v01/tab2"
 
     # Headers
     headers = {"accept": "application/json", "Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
- Remove `/app` prefix from route decorators in tab1.py, tab2.py, and test files
- Add `root_path` from `ROOT_PATH` env var to `FORM_API_META` in fastapi_config.py
- Add comments at the three places a developer would naturally hardcode a prefix: route decorators, `include_router`, and FastAPI config

## Context
All deployed backends had hardcoded service prefixes in route decorators (e.g. `/app/v01/tab1`), which caused doubled-prefix 404s when the frontend endpoint resolver also included the prefix in the base URL. This was fixed across all 7 backend repos — this PR updates the template so new apps start with clean routes from day one.
