### PR TITLE
Add security scanning and Dockerfile to FastAPI template

### DIFF
--- a/fastapi_app/copier.yml
+++ b/fastapi_app/copier.yml
@@ -1,5 +1,6 @@
 _min_copier_version: "9.0.0"
 _subdirectory: template
+_templates_suffix: ".jinja"
 
 # ── Questions ────────────────────────────────────────────────
 project_name:

--- a/fastapi_app/template/{{project_name}}/.github/workflows/security-scan.yml
+++ b/fastapi_app/template/{{project_name}}/.github/workflows/security-scan.yml
@@ -25,7 +25,6 @@ jobs:
       #   - run: uv audit --preview
       # TODO: remove continue-on-error once existing vulnerabilities are triaged
       - uses: pypa/gh-action-pip-audit@v1.1.0
-        continue-on-error: true
         with:
           inputs: "requirements.txt"
           no-deps: true
@@ -62,5 +61,5 @@ jobs:
         with:
           image-ref: scan-target:${{ github.sha }}
           format: table
-          exit-code: "0"
+          exit-code: "1"
           severity: CRITICAL,HIGH

--- a/fastapi_app/template/{{project_name}}/.github/workflows/security-scan.yml
+++ b/fastapi_app/template/{{project_name}}/.github/workflows/security-scan.yml
@@ -1,0 +1,66 @@
+name: Security Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    name: Dependency Audit (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # When migrating to uv, replace this step with:
+      #   - uses: astral-sh/setup-uv@v5
+      #   - run: uv audit --preview
+      # TODO: remove continue-on-error once existing vulnerabilities are triaged
+      - uses: pypa/gh-action-pip-audit@v1.1.0
+        continue-on-error: true
+        with:
+          inputs: "requirements.txt"
+          no-deps: true
+          summary: true
+
+  sast:
+    name: Static Analysis (Bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Bandit
+        run: pip install bandit
+
+      - name: Run Bandit
+        run: bandit -r app/ --severity-level medium --confidence-level medium
+
+  container-scan:
+    name: Container Scan (Trivy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image for scanning
+        run: docker build -t scan-target:${{ github.sha }} .
+
+      # TODO: set exit-code to 1 once base image CVEs are triaged
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: scan-target:${{ github.sha }}
+          format: table
+          exit-code: "0"
+          severity: CRITICAL,HIGH

--- a/fastapi_app/template/{{project_name}}/Dockerfile
+++ b/fastapi_app/template/{{project_name}}/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Adds **security scanning workflow** so every new project starts with pip-audit (SCA), Bandit (SAST), and Trivy (container scanning) out of the box
- Adds **Dockerfile** (python:3.11-slim, uvicorn) — previously referenced by devcontainer but never included
- Adds `_templates_suffix: ".jinja"` to copier.yml so GitHub Actions `${{ }}` expressions aren't misinterpreted as Jinja2. This makes the existing `.jinja` file convention explicit rather than relying on the default.

## What new projects get
```
MyProject/
├── .github/
│   └── workflows/
│       └── security-scan.yml   ← NEW
├── Dockerfile                  ← NEW
├── app/
│   └── ...
```

The security scan is standalone (not a reusable workflow caller) since this template is in a different org (UABPeriopAI) than the reusable workflow (UABGH-Emerging-Technologies).

## Test plan
- [ ] Generate a new project with `copier copy` and verify the workflow and Dockerfile are present
- [ ] Verify `.jinja` files still render correctly (project_name substitution, etc.)
- [ ] Verify non-`.jinja` files are copied as-is (no Jinja2 rendering of `${{ }}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)